### PR TITLE
Fix Claude Desktop configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 {
   "mcpServers": {
     "llms-txt-explorer": {
-      "command": "/path/to/llms-txt-explorer/build/index.js"
+      "command": "node",
+      "args": ["/path/to/llms-txt-explorer/build/index.js"],
     }
   }
 }


### PR DESCRIPTION
Update the configuration documentation for Claude Desktop to use the correct format. This fixes an issue where the path to the JS file was being incorrectly specified.

### Changes

- Changed the configuration format to use `command: "node"` and `args: ["/path/to/llms-txt-explorer/build/index.js"]` instead of putting the entire path in the command field
- This ensures the JS file is executed properly by Node.js rather than being treated as an executable itself

### Testing

Verified the updated configuration works correctly with Claude Desktop on both MacOS environment.